### PR TITLE
removed unnecessary newline's in echo statements

### DIFF
--- a/oemUnlock.sh
+++ b/oemUnlock.sh
@@ -4,36 +4,36 @@
 . ./common.sh
 
 # INIT
-echo "NETHUNTER LINUX FLASH (OEM UNLOCK)"
-echo "NOTE: THIS WILL FACTORY RESET THE DEVICE (15 secs to cancel using 'ctrl + c')"
+echo -ne "NETHUNTER LINUX FLASH (OEM UNLOCK)\n"
+echo -ne "NOTE: THIS WILL FACTORY RESET THE DEVICE (15 secs to cancel using 'ctrl + c')\n"
 sleep 15
-echo "CHECKING PRE-REQUISITES"
+echo -ne "CHECKING PRE-REQUISITES\n"
 
 doCommonChecks
 
-echo "CHECKING PRE-REQUISITES DONE"
+echo -ne "CHECKING PRE-REQUISITES DONE\n"
 sleep 3
 
 echo "Rebooting into bootloader"
 adb reboot bootloader
 sleep 5
-echo "Rebooting into bootloader DONE"
+echo -ne "Rebooting into bootloader DONE\n"
 
 echo "Starting OEM UNLOCK"
 echo "This needs you interaction. Check phone screen."
 fastboot oem unlock
-echo "OEM UNLOCK DONE"
+echo -ne "OEM UNLOCK DONE\n"
 
 echo "Rebooting the phone"
 fastboot continue
-echo "Rebooting the phone DONE"
+echo -ne "Rebooting the phone DONE\n"
 
 
 
 
-echo "It can take a bit to boot up, dont worry. ^^"
-echo "You will need to enable developer options and USB debugging again."
+echo -ne "It can take a bit to boot up, dont worry. ^^\n"
+echo -ne "You will need to enable developer options and USB debugging again.\n"
 
 echo "You can flash a stock rom using stockFlash.sh (Not needed if you are in latest android version)"
-echo "or continue flashing TWRP && superSU && Kali Nethunter using twrpFlash.sh script"
+echo -ne "or continue flashing TWRP && superSU && Kali Nethunter using twrpFlash.sh script\n"
 exit

--- a/oemUnlock.sh
+++ b/oemUnlock.sh
@@ -4,36 +4,36 @@
 . ./common.sh
 
 # INIT
-echo "NETHUNTER LINUX FLASH (OEM UNLOCK)\n"
-echo "NOTE: THIS WILL FACTORY RESET THE DEVICE (15 secs to cancel using 'ctrl + c')\n"
+echo "NETHUNTER LINUX FLASH (OEM UNLOCK)"
+echo "NOTE: THIS WILL FACTORY RESET THE DEVICE (15 secs to cancel using 'ctrl + c')"
 sleep 15
-echo "CHECKING PRE-REQUISITES\n"
+echo "CHECKING PRE-REQUISITES"
 
 doCommonChecks
 
-echo "CHECKING PRE-REQUISITES DONE\n"
+echo "CHECKING PRE-REQUISITES DONE"
 sleep 3
 
 echo "Rebooting into bootloader"
 adb reboot bootloader
 sleep 5
-echo "Rebooting into bootloader DONE\n"
+echo "Rebooting into bootloader DONE"
 
 echo "Starting OEM UNLOCK"
 echo "This needs you interaction. Check phone screen."
 fastboot oem unlock
-echo "OEM UNLOCK DONE\n"
+echo "OEM UNLOCK DONE"
 
 echo "Rebooting the phone"
 fastboot continue
-echo "Rebooting the phone DONE\n"
+echo "Rebooting the phone DONE"
 
 
 
 
-echo "It can take a bit to boot up, dont worry. ^^\n"
-echo "You will need to enable developer options and USB debugging again.\n"
+echo "It can take a bit to boot up, dont worry. ^^"
+echo "You will need to enable developer options and USB debugging again."
 
 echo "You can flash a stock rom using stockFlash.sh (Not needed if you are in latest android version)"
-echo "or continue flashing TWRP && superSU && Kali Nethunter using twrpFlash.sh script\n"
+echo "or continue flashing TWRP && superSU && Kali Nethunter using twrpFlash.sh script"
 exit

--- a/stockNexusFlash.sh
+++ b/stockNexusFlash.sh
@@ -13,10 +13,10 @@ romExtractionDir=_extracted
 
 # INIT
 
-echo "NETHUNTER LINUX FLASH (STOCK NEXUS GOOGLE IMAGES)"
-echo "NOTE: THIS WILL FACTORY RESET THE DEVICE (15 secs to cancel using 'ctrl + c')"
+echo -ne "NETHUNTER LINUX FLASH (STOCK NEXUS GOOGLE IMAGES)\n"
+echo -ne "NOTE: THIS WILL FACTORY RESET THE DEVICE (15 secs to cancel using 'ctrl + c')\n"
 sleep 15
-echo "CHECKING PRE-REQUISITES"
+echo -ne "CHECKING PRE-REQUISITES\n"
 
 doCommonChecks
 
@@ -24,40 +24,40 @@ isProgramInPath tar
 
 echo "Checking stock image existence"
 isEmpty $stockImageDir
-echo "Checking stock rom existence DONE"
+echo -ne "Checking stock rom existence DONE\n"
 
-echo "CHECKING PRE-REQUISITES DONE"
+echo -ne "CHECKING PRE-REQUISITES DONE\n"
 sleep 3
 
 echo "Creating tmp dir $romExtractionDir"
 mkdir $romExtractionDir
-echo "Creating tmp dir $romExtractionDir DONE"
+echo -ne "Creating tmp dir $romExtractionDir DONE\n"
 
 echo "Extracting $(ls $stockImageDir*)"
 tar -xvf $stockImageDir* -C $romExtractionDir
-echo "EXTACTING $(ls $stockImageDir*) DONE"
+echo -ne "EXTACTING $(ls $stockImageDir*) DONE\n"
 
 echo "cd to $romExtractionDir"
 cd $romExtractionDir/*
-echo "cd to $romExtractionDir DONE"
+echo -ne "cd to $romExtractionDir DONE\n"
 
 echo "Rebooting into bootloader"
 adb reboot bootloader
 sleep 5
-echo "Rebooting into bootloader DONE"
+echo -ne "Rebooting into bootloader DONE\n"
 
 echo "Flasing Stock Rom"
 echo "!!!! DONT UNPLUG THE DEVICE !!!!"
 ./flash-all.sh
-echo "Flasing Stock Rom DONE"
+echo -ne "Flasing Stock Rom DONE\n"
 
 echo "Deleting tmp dir $romExtractionDir"
 rm -rf ../../$romExtractionDir
-echo "Deleting $romExtractionDir DONE"
+echo -ne "Deleting $romExtractionDir DONE\n"
 
 # END
 
 echo "The device should be rebooting, once it is booted,"
-echo "do the initial setup, enable developer options and USB debugging again."
-echo "Next step is flashing TWRP && superSU && Kali Nethunter using twrpFlash.sh script"
+echo -ne "do the initial setup, enable developer options and USB debugging again.\n"
+echo -ne "Next step is flashing TWRP && superSU && Kali Nethunter using twrpFlash.sh script\n"
 exit

--- a/stockNexusFlash.sh
+++ b/stockNexusFlash.sh
@@ -13,10 +13,10 @@ romExtractionDir=_extracted
 
 # INIT
 
-echo "NETHUNTER LINUX FLASH (STOCK NEXUS GOOGLE IMAGES)\n"
-echo "NOTE: THIS WILL FACTORY RESET THE DEVICE (15 secs to cancel using 'ctrl + c')\n"
+echo "NETHUNTER LINUX FLASH (STOCK NEXUS GOOGLE IMAGES)"
+echo "NOTE: THIS WILL FACTORY RESET THE DEVICE (15 secs to cancel using 'ctrl + c')"
 sleep 15
-echo "CHECKING PRE-REQUISITES\n"
+echo "CHECKING PRE-REQUISITES"
 
 doCommonChecks
 
@@ -24,39 +24,40 @@ isProgramInPath tar
 
 echo "Checking stock image existence"
 isEmpty $stockImageDir
-echo "Checking stock rom existence DONE\n"
+echo "Checking stock rom existence DONE"
 
-echo "CHECKING PRE-REQUISITES DONE\n"
+echo "CHECKING PRE-REQUISITES DONE"
 sleep 3
 
 echo "Creating tmp dir $romExtractionDir"
 mkdir $romExtractionDir
-echo "Creating tmp dir $romExtractionDir DONE\n"
+echo "Creating tmp dir $romExtractionDir DONE"
 
 echo "Extracting $(ls $stockImageDir*)"
 tar -xvf $stockImageDir* -C $romExtractionDir
-echo "EXTACTING $(ls $stockImageDir*) DONE\n"
+echo "EXTACTING $(ls $stockImageDir*) DONE"
 
 echo "cd to $romExtractionDir"
 cd $romExtractionDir/*
-echo "cd to $romExtractionDir DONE\n"
+echo "cd to $romExtractionDir DONE"
 
 echo "Rebooting into bootloader"
 adb reboot bootloader
 sleep 5
-echo "Rebooting into bootloader DONE\n"
+echo "Rebooting into bootloader DONE"
 
-echo "Flasing Stock Rom\n!!!! DONT UNPLUG THE DEVICE !!!!"
+echo "Flasing Stock Rom"
+echo "!!!! DONT UNPLUG THE DEVICE !!!!"
 ./flash-all.sh
-echo "Flasing Stock Rom DONE\n"
+echo "Flasing Stock Rom DONE"
 
 echo "Deleting tmp dir $romExtractionDir"
 rm -rf ../../$romExtractionDir
-echo "Deleting $romExtractionDir DONE\n"
+echo "Deleting $romExtractionDir DONE"
 
 # END
 
 echo "The device should be rebooting, once it is booted,"
-echo "do the initial setup, enable developer options and USB debugging again.\n"
-echo "Next step is flashing TWRP && superSU && Kali Nethunter using twrpFlash.sh script\n"
+echo "do the initial setup, enable developer options and USB debugging again."
+echo "Next step is flashing TWRP && superSU && Kali Nethunter using twrpFlash.sh script"
 exit

--- a/stockOpoFlash.sh
+++ b/stockOpoFlash.sh
@@ -13,10 +13,10 @@ romExtractionDir=_extracted
 
 # INIT
 
-echo "NETHUNTER LINUX FLASH (STOCK OPO Fastboot IMAGES)"
-echo "NOTE: THIS WILL FACTORY RESET THE DEVICE (15 secs to cancel using 'ctrl + c')"
+echo -ne "NETHUNTER LINUX FLASH (STOCK OPO Fastboot IMAGES)\n"
+echo -ne "NOTE: THIS WILL FACTORY RESET THE DEVICE (15 secs to cancel using 'ctrl + c')\n"
 sleep 15
-echo "CHECKING PRE-REQUISITES"
+echo -ne "CHECKING PRE-REQUISITES\n"
 
 doCommonChecks
 
@@ -24,29 +24,29 @@ isProgramInPath unzip
 
 echo "Checking stock image existence"
 isEmpty $stockImageDir
-echo "Checking stock rom existence DONE"
+echo -ne "Checking stock rom existence DONE\n"
 
 opoModelCheck $1
 
-echo "CHECKING PRE-REQUISITES DONE"
+echo -ne "CHECKING PRE-REQUISITES DONE\n"
 sleep 3
 
 echo "Creating tmp dir $romExtractionDir"
 mkdir $romExtractionDir
-echo "Creating tmp dir $romExtractionDir DONE"
+echo -ne "Creating tmp dir $romExtractionDir DONE\n"
 
 echo "Extracting $(ls $stockImageDir*)"
 unzip $stockImageDir* -d  $romExtractionDir
-echo "EXTACTING $(ls $stockImageDir*) DONE"
+echo -ne "EXTACTING $(ls $stockImageDir*) DONE\n"
 
 echo "cd to $romExtractionDir"
 cd $romExtractionDir/
-echo "cd to $romExtractionDir DONE"
+echo -ne "cd to $romExtractionDir DONE\n"
 
 echo "Rebooting into bootloader"
 adb reboot bootloader
 sleep 5
-echo "Rebooting into bootloader DONE"
+echo -ne "Rebooting into bootloader DONE\n"
 
 echo "Flasing Stock Rom"
 echo "!!!! DONT UNPLUG THE DEVICE !!!!"
@@ -88,15 +88,15 @@ sleep 3
 fastboot flash cache cache.img
 sleep 3
 fastboot continue
-echo "Flasing Stock Rom DONE"
+echo -ne "Flasing Stock Rom DONE\n"
 
 echo "Deleting tmp dir $romExtractionDir"
 rm -rf ../$romExtractionDir
-echo "Deleting $romExtractionDir DONE"
+echo -ne "Deleting $romExtractionDir DONE\n"
 
 # END
 
 echo "The device should be rebooting, once it is booted,"
-echo "do the initial setup, enable developer options and USB debugging again."
-echo "Next step is flashing TWRP && superSU && Kali Nethunter using twrpFlash.sh script"
+echo -ne "do the initial setup, enable developer options and USB debugging again.\n"
+echo -ne "Next step is flashing TWRP && superSU && Kali Nethunter using twrpFlash.sh script\n"
 exit

--- a/stockOpoFlash.sh
+++ b/stockOpoFlash.sh
@@ -13,10 +13,10 @@ romExtractionDir=_extracted
 
 # INIT
 
-echo "NETHUNTER LINUX FLASH (STOCK OPO Fastboot IMAGES)\n"
-echo "NOTE: THIS WILL FACTORY RESET THE DEVICE (15 secs to cancel using 'ctrl + c')\n"
+echo "NETHUNTER LINUX FLASH (STOCK OPO Fastboot IMAGES)"
+echo "NOTE: THIS WILL FACTORY RESET THE DEVICE (15 secs to cancel using 'ctrl + c')"
 sleep 15
-echo "CHECKING PRE-REQUISITES\n"
+echo "CHECKING PRE-REQUISITES"
 
 doCommonChecks
 
@@ -24,31 +24,32 @@ isProgramInPath unzip
 
 echo "Checking stock image existence"
 isEmpty $stockImageDir
-echo "Checking stock rom existence DONE\n"
+echo "Checking stock rom existence DONE"
 
 opoModelCheck $1
 
-echo "CHECKING PRE-REQUISITES DONE\n"
+echo "CHECKING PRE-REQUISITES DONE"
 sleep 3
 
 echo "Creating tmp dir $romExtractionDir"
 mkdir $romExtractionDir
-echo "Creating tmp dir $romExtractionDir DONE\n"
+echo "Creating tmp dir $romExtractionDir DONE"
 
 echo "Extracting $(ls $stockImageDir*)"
 unzip $stockImageDir* -d  $romExtractionDir
-echo "EXTACTING $(ls $stockImageDir*) DONE\n"
+echo "EXTACTING $(ls $stockImageDir*) DONE"
 
 echo "cd to $romExtractionDir"
 cd $romExtractionDir/
-echo "cd to $romExtractionDir DONE\n"
+echo "cd to $romExtractionDir DONE"
 
 echo "Rebooting into bootloader"
 adb reboot bootloader
 sleep 5
-echo "Rebooting into bootloader DONE\n"
+echo "Rebooting into bootloader DONE"
 
-echo "Flasing Stock Rom\n!!!! DONT UNPLUG THE DEVICE !!!!"
+echo "Flasing Stock Rom"
+echo "!!!! DONT UNPLUG THE DEVICE !!!!"
 
 fastboot flash sbl1 sbl1.mbn
 sleep 3
@@ -87,15 +88,15 @@ sleep 3
 fastboot flash cache cache.img
 sleep 3
 fastboot continue
-echo "Flasing Stock Rom DONE\n"
+echo "Flasing Stock Rom DONE"
 
 echo "Deleting tmp dir $romExtractionDir"
 rm -rf ../$romExtractionDir
-echo "Deleting $romExtractionDir DONE\n"
+echo "Deleting $romExtractionDir DONE"
 
 # END
 
 echo "The device should be rebooting, once it is booted,"
-echo "do the initial setup, enable developer options and USB debugging again.\n"
-echo "Next step is flashing TWRP && superSU && Kali Nethunter using twrpFlash.sh script\n"
+echo "do the initial setup, enable developer options and USB debugging again."
+echo "Next step is flashing TWRP && superSU && Kali Nethunter using twrpFlash.sh script"
 exit

--- a/twrpFlash.sh
+++ b/twrpFlash.sh
@@ -25,55 +25,55 @@ sdnh="/sdcard/kaliNethunter.zip"
 
 # INIT
 
-echo "NETHUNTER LINUX FLASH (TWRP, SuperSU and Kali Nethunter)\n"
+echo "NETHUNTER LINUX FLASH (TWRP, SuperSU and Kali Nethunter)"
 
-echo "CHECKING PRE-REQUISITES\n"
+echo "CHECKING PRE-REQUISITES"
 
 doCommonChecks
 
 echo "Checking TWRP image existence"
 isEmpty $twrpImageDir
-echo "Checking TWRP image existence DONE\n"
+echo "Checking TWRP image existence DONE"
 
 echo "Checking SuperSu existence"
 isEmpty $superSuDir
-echo "Checking SuperSu existence DONE\n"
+echo "Checking SuperSu existence DONE"
 
 echo "Checking Kali Nethunter zip existence"
 isEmpty $nhDir
-echo "Checking Kali Nethunter zip existence DONE\n"
+echo "Checking Kali Nethunter zip existence DONE"
 
-echo "CHECKING PRE-REQUISITES DONE\n"
+echo "CHECKING PRE-REQUISITES DONE"
 sleep 3
 
 echo "Sending Kali Nethunter zip to the device"
 adb push -p $nhZip $sdnh
 sleep 3
-echo "Sending Kali Nethunter zip to the device DONE\n"
+echo "Sending Kali Nethunter zip to the device DONE"
 
 echo "Sending SuperSu zip to the device"
 adb push -p $superSuZip $sdSupersu
 sleep 3
-echo "Sending SuperSu zip to the device DONE\n"
+echo "Sending SuperSu zip to the device DONE"
 
 echo "Rebooting into bootloader"
 adb reboot bootloader
 sleep 5
-echo "Rebooting into bootloader DONE\n"
+echo "Rebooting into bootloader DONE"
 
 echo "Flashing TWRP image"
 fastboot flash recovery $twrpImage
 sleep 3
-echo "Flashing TWRP image DONE\n"
+echo "Flashing TWRP image DONE"
 
 echo "Booting into TWRP (20 secs dont worry)"
 fastboot boot $twrpImage
 sleep 20
-echo "Booting into TWRP DONE\n"
+echo "Booting into TWRP DONE"
 
 echo "Installing SuperSU"
 adb shell "twrp install $sdSupersu"
-echo "Installing SuperSU DONE!\n"
+echo "Installing SuperSU DONE!"
 
 echo "Installing Kali Linux Nethunter"
 sleep 5
@@ -83,6 +83,6 @@ echo "Installing Kali Linux Nethunter DONE!"
 echo "Rebooting into Kali Linux Nethunter"
 sleep 3
 adb reboot
-echo "Everything is installed. Phone should be booting up! Enjoy\n"
+echo "Everything is installed. Phone should be booting up! Enjoy"
 exit
 

--- a/twrpFlash.sh
+++ b/twrpFlash.sh
@@ -25,55 +25,55 @@ sdnh="/sdcard/kaliNethunter.zip"
 
 # INIT
 
-echo "NETHUNTER LINUX FLASH (TWRP, SuperSU and Kali Nethunter)"
+echo -ne "NETHUNTER LINUX FLASH (TWRP, SuperSU and Kali Nethunter)\n"
 
-echo "CHECKING PRE-REQUISITES"
+echo -ne "CHECKING PRE-REQUISITES\n"
 
 doCommonChecks
 
 echo "Checking TWRP image existence"
 isEmpty $twrpImageDir
-echo "Checking TWRP image existence DONE"
+echo -ne "Checking TWRP image existence DONE\n"
 
 echo "Checking SuperSu existence"
 isEmpty $superSuDir
-echo "Checking SuperSu existence DONE"
+echo -ne "Checking SuperSu existence DONE\n"
 
 echo "Checking Kali Nethunter zip existence"
 isEmpty $nhDir
-echo "Checking Kali Nethunter zip existence DONE"
+echo -ne "Checking Kali Nethunter zip existence DONE\n"
 
-echo "CHECKING PRE-REQUISITES DONE"
+echo -ne "CHECKING PRE-REQUISITES DONE\n"
 sleep 3
 
 echo "Sending Kali Nethunter zip to the device"
 adb push -p $nhZip $sdnh
 sleep 3
-echo "Sending Kali Nethunter zip to the device DONE"
+echo -ne "Sending Kali Nethunter zip to the device DONE\n"
 
 echo "Sending SuperSu zip to the device"
 adb push -p $superSuZip $sdSupersu
 sleep 3
-echo "Sending SuperSu zip to the device DONE"
+echo -ne "Sending SuperSu zip to the device DONE\n"
 
 echo "Rebooting into bootloader"
 adb reboot bootloader
 sleep 5
-echo "Rebooting into bootloader DONE"
+echo -ne "Rebooting into bootloader DONE\n"
 
 echo "Flashing TWRP image"
 fastboot flash recovery $twrpImage
 sleep 3
-echo "Flashing TWRP image DONE"
+echo -ne "Flashing TWRP image DONE\n"
 
 echo "Booting into TWRP (20 secs dont worry)"
 fastboot boot $twrpImage
 sleep 20
-echo "Booting into TWRP DONE"
+echo -ne "Booting into TWRP DONE\n"
 
 echo "Installing SuperSU"
 adb shell "twrp install $sdSupersu"
-echo "Installing SuperSU DONE!"
+echo -ne "Installing SuperSU DONE!\n"
 
 echo "Installing Kali Linux Nethunter"
 sleep 5
@@ -83,6 +83,6 @@ echo "Installing Kali Linux Nethunter DONE!"
 echo "Rebooting into Kali Linux Nethunter"
 sleep 3
 adb reboot
-echo "Everything is installed. Phone should be booting up! Enjoy"
+echo -ne "Everything is installed. Phone should be booting up! Enjoy\n"
 exit
 


### PR DESCRIPTION
Saw this when I was installing nethunter, decided to throw a quick PR at it.  The newline's were getting printed out with the text instead of creating newlines.  `echo` returns to a new line after printing it's text, so I removed the `\n`'s.
